### PR TITLE
fixes key

### DIFF
--- a/src/MapView.js
+++ b/src/MapView.js
@@ -18,5 +18,5 @@ export class MapView extends Component {
 }
 
 export default GoogleApiWrapper({
-  apiKey: process.env.GOOGLE
+  apiKey: process.env.GOOGLE_MAP_KEY
 })(MapView)


### PR DESCRIPTION
The problem is the ENV for your project was called GOOGLE_MAP_KEY which is different for the GOOGLE node var. This is confusing but we can chat about this tomorrow. 

A better fix would be to switch the name GOOGLE to GOOGLE_MAP_KEY across the board, it is more descriptive.

